### PR TITLE
Add data to admin dashboard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
 
 before_script:
 - mv configs/test_settings_deployment.py coordinated-entry-screening/settings_deployment.py
-script: python manage.py migrate
+script: python manage.py migrate && pytest
 
 deploy:
   provider: codedeploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
 
 before_script:
 - mv configs/test_settings_deployment.py coordinated-entry-screening/settings_deployment.py
-script: python manage.py migrate && pytest
+script: python manage.py migrate
 
 deploy:
   provider: codedeploy

--- a/ces_admin/urls.py
+++ b/ces_admin/urls.py
@@ -1,9 +1,11 @@
 from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
 
-from . import views
+from ces_admin.views import ces_login, ces_logout
+from ces_admin.views import DashboardView
 
 urlpatterns = [
-    url(r'^ces-login/$', views.ces_login, name='ces_login'),
-    url(r'^ces-logout/$', views.ces_logout, name='ces_logout'),
-    url(r'^ces-admin/$', views.ces_admin, name='ces_admin'),
+    url(r'^ces-login/$', ces_login, name='ces_login'),
+    url(r'^ces-logout/$', ces_logout, name='ces_logout'),
+    url(r'^dashboard/$', login_required(DashboardView.as_view(), login_url='/ces-login/'), name='dashboard'),
 ]

--- a/ces_admin/utils.py
+++ b/ces_admin/utils.py
@@ -1,0 +1,7 @@
+from collections import namedtuple
+
+def make_namedtuple(cursor, query):
+    cursor.execute(query)
+    fields = cursor.description
+    nt_result = namedtuple('Session', [col[0] for col in fields])
+    return [nt_result(*row) for row in cursor.fetchall()]

--- a/ces_admin/utils.py
+++ b/ces_admin/utils.py
@@ -1,7 +1,9 @@
 from collections import namedtuple
 
-def make_namedtuple(cursor, query):
+def prepare_data(cursor, query):
     cursor.execute(query)
-    fields = cursor.description
-    nt_result = namedtuple('Session', [col[0] for col in fields])
-    return [nt_result(*row) for row in cursor.fetchall()]
+    data = cursor.fetchall()
+    data_for_chart = [{'name': tup[0], 'y': tup[1]} for tup in data]
+    mapping = {tup[0]: tup[2] for tup in data}
+
+    return data_for_chart, mapping

--- a/ces_admin/utils.py
+++ b/ces_admin/utils.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import json
 
 def prepare_data(cursor, query):
     cursor.execute(query)
@@ -6,4 +7,4 @@ def prepare_data(cursor, query):
     data_for_chart = [{'name': tup[0], 'y': tup[1]} for tup in data]
     mapping = {tup[0]: tup[2] for tup in data}
 
-    return data_for_chart, mapping
+    return json.dumps(data_for_chart), json.dumps(mapping)

--- a/ces_admin/views.py
+++ b/ces_admin/views.py
@@ -13,7 +13,7 @@ from django.db.models import Q
 
 from decisiontree.models import Session
 
-from .utils import make_namedtuple
+from .utils import prepare_data
 
 
 def ces_login(request):
@@ -36,17 +36,18 @@ def ces_logout(request):
 def ces_admin(request):
     with connection.cursor() as cursor:
         base_query = '''
-            SELECT count(state.name) as count, state.name
+            SELECT message.text, count(state.name) as count, state.name
             FROM decisiontree_session as session
             JOIN decisiontree_treestate as state
             ON session.{state_type}=state.id
+            JOIN decisiontree_message as message
+            ON state.message_id=message.id
             {where_clause}
-            GROUP BY state.name
+            GROUP BY state.name, message.text
             ORDER BY count DESC
         '''
 
         one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
-
 
         # Sessions that are in progress
         open_sessions = Session.objects.filter(state_id__isnull=False, last_modified__gte=one_day_ago).count()
@@ -54,9 +55,8 @@ def ces_admin(request):
         query_chart = base_query.format(state_type='state_id',
                                         where_clause="WHERE session.state_id is not null " +
                                                      "AND session.last_modified >= (NOW() - INTERVAL '24 hour')")
-        cursor.execute(query_chart)
-        data = cursor.fetchall()
-        open_sessions_chart = [{'name': tup[1], 'y': tup[0]} for tup in data]
+
+        open_sessions_chart, open_sessions_map = prepare_data(cursor, query_chart)
 
         # Sessions that the user either canceled (e.g., by typing "end") or abandoned 24 hours after starting.
         canceled_sessions = Session.objects.filter(Q(state_id__isnull=True, canceled=True) | Q(state_id__isnull=False, last_modified__lt=one_day_ago)).count()
@@ -67,29 +67,20 @@ def ces_admin(request):
                                                      "OR (session.state_id is not null " +
                                                      "AND session.last_modified < (NOW() - INTERVAL '24 hour'))")
 
-        cursor.execute(query_chart)
-        data = cursor.fetchall()
-
-        # import pdb
-        # pdb.set_trace()
-        canceled_sessions_chart = [{'name': tup[1], 'y': tup[0]} for tup in data]
-
+        canceled_sessions_chart, canceled_sessions_map = prepare_data(cursor, query_chart)
 
         # Sessions that the user completed, e.g., by answering all questions in the survey
         completed_sessions = Session.objects.filter(state_id__isnull=True, canceled=False).count()
 
         query_chart = base_query.format(state_type="state_at_close_id",
-                                              where_clause="WHERE session.state_id is null " +
-                                                           "AND session.canceled=False")
+                                        where_clause="WHERE session.state_id is null " +
+                                                     "AND session.canceled=False")
 
-
-        cursor.execute(query_chart)
-        data = cursor.fetchall()
-        completed_sessions_chart = [{'name': tup[1], 'y': tup[0]} for tup in data]
+        completed_sessions_chart, completed_sessions_map = prepare_data(cursor, query_chart)
 
         # Recommendations
         query_chart = '''
-            SELECT count(message.text) as count, message.text 
+            SELECT message.text, count(message.text) as count, state.name 
             FROM decisiontree_session as session 
             JOIN decisiontree_entry as entry 
             ON session.id=entry.session_id 
@@ -100,19 +91,24 @@ def ces_admin(request):
             JOIN decisiontree_message as message 
             ON message.id=state.message_id
             WHERE message.recommendation=True
-            GROUP BY message.text
+            GROUP BY message.text, state.name
             ORDER BY count DESC
         '''
         cursor.execute(query_chart)
         data = cursor.fetchall()
-        resources_chart = [{'name': tup[1], 'y': tup[0]} for tup in data]
+        resources_chart = [{'name': tup[0], 'y': tup[1]} for tup in data]
+        resources_map = {tup[0]: tup[2] for tup in data}
 
     return render(request, 'ces_admin/ces-dashboard.html', {
             'open_sessions': open_sessions,
             'open_sessions_chart': json.dumps(open_sessions_chart),
+            'open_sessions_map': json.dumps(open_sessions_map),
             'canceled_sessions': canceled_sessions,
             'canceled_sessions_chart': json.dumps(canceled_sessions_chart),
+            'canceled_sessions_map': json.dumps(canceled_sessions_map),
             'completed_sessions': completed_sessions,
             'completed_sessions_chart': json.dumps(completed_sessions_chart),
+            'completed_sessions_map': json.dumps(completed_sessions_map),
             'resources_chart': json.dumps(resources_chart),
+            'resources_map': json.dumps(resources_map),
         })

--- a/ces_admin/views.py
+++ b/ces_admin/views.py
@@ -1,9 +1,14 @@
+from collections import namedtuple
+
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import authenticate, login, logout
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.shortcuts import render
+from django.db import connection
+
+from decisiontree.models import Session
 
 
 def ces_login(request):
@@ -24,4 +29,22 @@ def ces_logout(request):
 
 @login_required(login_url='/ces-login/')
 def ces_admin(request):
-    return render(request, 'ces_admin/ces-admin.html')
+    with connection.cursor() as cursor:
+        query_open_sessions ='''
+            SELECT session.start_date, session.last_modified, message.text
+            FROM decisiontree_session as session
+            JOIN decisiontree_treestate as state
+            ON session.state_id=state.id
+            JOIN decisiontree_message as message
+            ON state.message_id=message.id 
+            WHERE session.canceled is not True
+        '''
+        
+        cursor.execute(query_open_sessions)
+        fields = cursor.description
+        nt_result = namedtuple('Session', [col[0] for col in fields])
+        open_sessions = [nt_result(*row) for row in cursor.fetchall()]
+
+    return render(request, 'ces_admin/ces-dashboard.html', {
+            "open_sessions": open_sessions,
+        })

--- a/ces_admin/views.py
+++ b/ces_admin/views.py
@@ -33,80 +33,117 @@ def ces_logout(request):
     logout(request)
     return HttpResponseRedirect('/')
 
-class DashboardView(TemplateView):
+class DashboardContextMixin(object):
+    query_for_session_data = '''
+        SELECT message.text, count(state.name) as count, state.name
+        FROM decisiontree_session as session
+        JOIN decisiontree_treestate as state
+        ON session.{state_type}=state.id
+        JOIN decisiontree_message as message
+        ON state.message_id=message.id
+        {where_clause}
+        GROUP BY state.name, message.text
+        ORDER BY count DESC
+    '''
+
+    one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+
+    def get_context_sessions_in_progress(self):
+        '''
+        This function gets context data for sessions that are "in progress," 
+        i.e., not canceled, not completed, and opened in the last 24 hours.
+        '''
+        context = {}
+
+        with connection.cursor() as cursor:
+            context['open_sessions'] = Session.objects.filter(state_id__isnull=False, last_modified__gte=self.one_day_ago).count()
+
+            query = self.query_for_session_data.format(state_type='state_id',
+                                                       where_clause='''WHERE session.state_id is not null 
+                                                                       AND session.last_modified >= (NOW() - INTERVAL '24 hour')''')
+
+            open_sessions_chart, open_sessions_map = prepare_data(cursor, query)
+            context['open_sessions_chart'] = open_sessions_chart
+            context['open_sessions_map'] = open_sessions_map
+
+        return context
+
+    def get_context_canceled_sessions(self):
+        '''
+        This function gets context data for sessions that the user either canceled (e.g., by typing "end") 
+        or abandoned 24 hours after starting.
+        '''
+        context = {}
+
+        with connection.cursor() as cursor:
+            context['canceled_sessions'] = Session.objects.filter(Q(state_id__isnull=True, canceled=True) | Q(state_id__isnull=False, last_modified__lt=self.one_day_ago)).count()
+
+            query = self.query_for_session_data.format(state_type='state_at_close_id',
+                                                       where_clause='''WHERE (session.state_id is null 
+                                                                       AND session.canceled=True) 
+                                                                       OR (session.state_id is not null 
+                                                                       AND session.last_modified < (NOW() - INTERVAL '24 hour'))''')
+
+            canceled_sessions_chart, canceled_sessions_map = prepare_data(cursor, query)
+            context['canceled_sessions_chart'] = canceled_sessions_chart
+            context['canceled_sessions_map'] = canceled_sessions_map
+
+        return context
+
+    def get_context_completed_sessions(self):
+        '''
+        This function gets context data for sessions that the user completed 
+        by answering all relevant questions in the survey
+        '''
+        context = {}
+
+        with connection.cursor() as cursor:
+            context['completed_sessions'] = Session.objects.filter(state_id__isnull=True, canceled=False).count()
+
+            query = self.query_for_session_data.format(state_type='state_at_close_id',
+                                                       where_clause='''WHERE session.state_id is null
+                                                                       AND session.canceled=False''')
+
+            completed_sessions_chart, completed_sessions_map = prepare_data(cursor, query)
+            context['completed_sessions_chart'] = completed_sessions_chart
+            context['completed_sessions_map'] = completed_sessions_map
+
+        return context
+
+class DashboardView(DashboardContextMixin, TemplateView):
     template_name = 'ces_admin/ces-dashboard.html'
     
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         
-        base_query = '''
-            SELECT message.text, count(state.name) as count, state.name
-            FROM decisiontree_session as session
-            JOIN decisiontree_treestate as state
-            ON session.{state_type}=state.id
-            JOIN decisiontree_message as message
-            ON state.message_id=message.id
-            {where_clause}
-            GROUP BY state.name, message.text
-            ORDER BY count DESC
-        '''
+        context_for_sessions = self.get_context_sessions_in_progress()
+        context.update(context_for_sessions)
 
-        one_day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+        context_for_sessions = self.get_context_canceled_sessions()
+        context.update(context_for_sessions)
+
+        context_for_sessions = self.get_context_completed_sessions()
+        context.update(context_for_sessions)
 
         with connection.cursor() as cursor:
-            # Sessions that are in progress
-            context['open_sessions'] = Session.objects.filter(state_id__isnull=False, last_modified__gte=one_day_ago).count()
-
-            query_chart = base_query.format(state_type='state_id',
-                                            where_clause="WHERE session.state_id is not null " +
-                                                         "AND session.last_modified >= (NOW() - INTERVAL '24 hour')")
-
-            open_sessions_chart, open_sessions_map = prepare_data(cursor, query_chart)
-            context['open_sessions_chart'] = json.dumps(open_sessions_chart)
-            context['open_sessions_map'] = json.dumps(open_sessions_map)
-
-            # Sessions that the user either canceled (e.g., by typing "end") or abandoned 24 hours after starting.
-            context['canceled_sessions'] = Session.objects.filter(Q(state_id__isnull=True, canceled=True) | Q(state_id__isnull=False, last_modified__lt=one_day_ago)).count()
-
-            query_chart = base_query.format(state_type='state_at_close_id',
-                                            where_clause="WHERE (session.state_id is null " +
-                                                         "AND session.canceled=True) " +
-                                                         "OR (session.state_id is not null " +
-                                                         "AND session.last_modified < (NOW() - INTERVAL '24 hour'))")
-
-            canceled_sessions_chart, canceled_sessions_map = prepare_data(cursor, query_chart)
-            context['canceled_sessions_chart'] = json.dumps(canceled_sessions_chart)
-            context['canceled_sessions_map'] = json.dumps(canceled_sessions_map)
-
-            # Sessions that the user completed, e.g., by answering all questions in the survey
-            context['completed_sessions'] = Session.objects.filter(state_id__isnull=True, canceled=False).count()
-
-            query_chart = base_query.format(state_type="state_at_close_id",
-                                            where_clause="WHERE session.state_id is null " +
-                                                         "AND session.canceled=False")
-
-            completed_sessions_chart, completed_sessions_map = prepare_data(cursor, query_chart)
-            context['completed_sessions_chart'] = json.dumps(completed_sessions_chart)
-            context['completed_sessions_map'] = json.dumps(completed_sessions_map)
-
             # Recommendations
-            query_chart = '''
+            query_for_recommendation_chart = '''
                 SELECT message.text, count(message.text) as count, state.name 
                 FROM decisiontree_session as session 
                 JOIN decisiontree_entry as entry 
-                ON session.id=entry.session_id 
+                ON session.id = entry.session_id 
                 JOIN decisiontree_transition as transition 
-                ON transition.id=entry.transition_id 
+                ON transition.id = entry.transition_id 
                 JOIN decisiontree_treestate as state 
-                ON state.id=transition.next_state_id 
+                ON state.id = transition.next_state_id 
                 JOIN decisiontree_message as message 
-                ON message.id=state.message_id
+                ON message.id = state.message_id
                 WHERE message.recommendation=True
                 GROUP BY message.text, state.name
                 ORDER BY count DESC
             '''
-            resources_chart, resources_map = prepare_data(cursor, query_chart)
-            context['resources_chart'] = json.dumps(resources_chart)
-            context['resources_map'] = json.dumps(resources_map)           
+            resources_chart, resources_map = prepare_data(cursor, query_for_recommendation_chart)
+            context['resources_chart'] = resources_chart
+            context['resources_map'] = resources_map           
 
         return context

--- a/coordinated-entry-screening/static/css/custom.css
+++ b/coordinated-entry-screening/static/css/custom.css
@@ -1,0 +1,6 @@
+.highcharts-tooltip span {
+    height: auto;
+    width: 200px;;
+    overflow: auto;
+    white-space: normal !important;
+}

--- a/coordinated-entry-screening/static/js/dashboard-charts.js
+++ b/coordinated-entry-screening/static/js/dashboard-charts.js
@@ -1,7 +1,7 @@
 function barHelper(container, prepped_data){
     Highcharts.chart(container, {
         chart: {
-            type: 'column'
+            type: 'bar'
         },
         title: {
             text: null

--- a/coordinated-entry-screening/static/js/dashboard-charts.js
+++ b/coordinated-entry-screening/static/js/dashboard-charts.js
@@ -1,4 +1,4 @@
-function barHelper(container, prepped_data){
+function barHelper(container, prepped_data, data_map){
     Highcharts.chart(container, {
         chart: {
             type: 'bar'
@@ -10,13 +10,18 @@ function barHelper(container, prepped_data){
             text: null
         },
         xAxis: {
-            type: 'category'
+            type: 'category',
+            labels: {
+                formatter: function () {
+                   return data_map[this.value];
+                },
+            },
         },
         yAxis: {
             title: {
                 text: 'Number of users'
-            }
-
+            },
+            allowDecimals: false
         },
         legend: {
             enabled: false
@@ -24,23 +29,25 @@ function barHelper(container, prepped_data){
         plotOptions: {
             series: {
                 borderWidth: 0,
-                dataLabels: {
-                    enabled: true,
-                    format: '{point.y:.1f}%'
-                }
             }
         },
-
         tooltip: {
-            headerFormat: '<span style="font-size:11px">{series.name}</span><br>',
-            pointFormat: '<span style="color:{point.color}">{point.name}</span>: <b>{point.y:.2f}%</b> of total<br/>'
+            backgroundColor: 'rgba(236, 240, 241, .85)',
+            style: {
+                color: '#3B4B5C',
+            },
+            useHTML: true,
+            headerFormat: '',
+            pointFormat:  '<h6><strong>{point.y} users</strong></h6><hr><p>{point.name}</p>',
+            shared: true,
+            shadow: false,
+            borderColor: '#3B4B5C'
         },
-
-        "series": [
+        series: [
             {
                 "name": "Number of users",
                 "colorByPoint": true,
-                "data": JSON.parse(prepped_data)
+                "data": prepped_data
             }
         ]
     });

--- a/coordinated-entry-screening/static/js/dashboard-charts.js
+++ b/coordinated-entry-screening/static/js/dashboard-charts.js
@@ -1,0 +1,47 @@
+function barHelper(prepped_data){
+    Highcharts.chart('container', {
+        chart: {
+            type: 'column'
+        },
+        title: {
+            text: null
+        },
+        subtitle: {
+            text: null
+        },
+        xAxis: {
+            type: 'category'
+        },
+        yAxis: {
+            title: {
+                text: 'Number of users'
+            }
+
+        },
+        legend: {
+            enabled: false
+        },
+        plotOptions: {
+            series: {
+                borderWidth: 0,
+                dataLabels: {
+                    enabled: true,
+                    format: '{point.y:.1f}%'
+                }
+            }
+        },
+
+        tooltip: {
+            headerFormat: '<span style="font-size:11px">{series.name}</span><br>',
+            pointFormat: '<span style="color:{point.color}">{point.name}</span>: <b>{point.y:.2f}%</b> of total<br/>'
+        },
+
+        "series": [
+            {
+                "name": "Number of users",
+                "colorByPoint": true,
+                "data": JSON.parse(prepped_data)
+            }
+        ]
+    });
+}

--- a/coordinated-entry-screening/static/js/dashboard-charts.js
+++ b/coordinated-entry-screening/static/js/dashboard-charts.js
@@ -1,5 +1,5 @@
-function barHelper(prepped_data){
-    Highcharts.chart('container', {
+function barHelper(container, prepped_data){
+    Highcharts.chart(container, {
         chart: {
             type: 'column'
         },

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = tests.test_config

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,10 @@
 
     <script src="{% static "js/jquery-3.3.1.min.js" %}" type="text/javascript"></script>
     <script src="{% static "js/bootstrap.min.js" %}" type="text/javascript"></script>
+
+
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="{% static "js/dashboard-charts.js" %}" type="text/javascript"></script>
     {% block extra_javascript %}{% endblock extra_javascript %}
 </body>
 </html>

--- a/templates/ces_admin/ces-admin.html
+++ b/templates/ces_admin/ces-admin.html
@@ -1,1 +1,0 @@
-Welcome admin. Learn about your users.

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -4,6 +4,13 @@
 
 
 <h2>Open sessions</h2>
+<div class='row'>
+    <div class='col-md-12'>
+        <h4><span class='badge badge-pill badge-primary'>{{ open_sessions | length }}</span> users have open sessions</h4>
+        <p>These users are currently completing a survey.</p>
+        <div id="open-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+    </div>
+</div>
 {% if open_sessions %}
 <table class="table">
     <thead>
@@ -24,6 +31,8 @@
     </tbody>
 </table>
 {% endif %}
+
+
 
 <h2>Closed sessions</h2>
 {% if closed_sessions %}
@@ -46,6 +55,8 @@
     </tbody>
 </table>
 {% endif %}
+
+
 
 <h2>Canceled sessions</h2>
 <div class='row'>
@@ -87,8 +98,12 @@
 
 <script>
     $(function() {
-        prepped_data = '{{canceled_chart | escapejs}}';
-        barHelper(prepped_data);
+        open_chart = '{{open_chart | escapejs}}'
+        barHelper('open-chart' ,open_chart);
+
+        canceled_chart = '{{canceled_chart | escapejs}}';
+        barHelper('container', canceled_chart);
+
     });
 </script>
 

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -63,7 +63,7 @@
     <div class='col-md-12'>
         <h4><span class='badge badge-pill badge-primary'>{{ canceled_sessions | length }}</span> users canceled their session</h4>
         <p>These users instructed the tool to close thier session, for example, by typing "end." This data shows the question on which users closed their sessions.</p>
-        <div id="container" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+        <div id="canceled-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
     </div>
 </div>
 
@@ -102,7 +102,7 @@
         barHelper('open-chart' ,open_chart);
 
         canceled_chart = '{{canceled_chart | escapejs}}';
-        barHelper('container', canceled_chart);
+        barHelper('canceled-chart', canceled_chart);
 
     });
 </script>

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -23,4 +23,46 @@
 </table>
 {% endif %}
 
+{% if closed_sessions %}
+<table class="table">
+    <thead>
+        <tr>
+            <th scope="col">Start date</th>
+            <th scope="col">Last modified</th>
+            <th scope="col">Text</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for session in closed_sessions %}
+        <tr>
+            <td>{{session.start_date}}</td>
+            <td>{{session.last_modified}}</td>
+            <td>{{session.text}}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+
+{% if canceled_sessions %}
+<table class="table">
+    <thead>
+        <tr>
+            <th scope="col">Start date</th>
+            <th scope="col">Last modified</th>
+            <th scope="col">Text</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for session in canceled_sessions %}
+        <tr>
+            <td>{{session.start_date}}</td>
+            <td>{{session.last_modified}}</td>
+            <td>{{session.text}}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+
 {% endblock %}

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -6,91 +6,42 @@
 <h2>Open sessions</h2>
 <div class='row'>
     <div class='col-md-12'>
-        <h4><span class='badge badge-pill badge-primary'>{{ open_sessions | length }}</span> users have open sessions</h4>
-        <p>These users are currently completing a survey.</p>
+        <h4><span class='badge badge-pill badge-primary'>{{ open_sessions }}</span> users have open sessions</h4>
+        <p>These users started a survey in the last 24 hours.</p>
         <div id="open-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
     </div>
 </div>
-{% if open_sessions %}
-<table class="table">
-    <thead>
-        <tr>
-            <th scope="col">Start date</th>
-            <th scope="col">Last modified</th>
-            <th scope="col">Text</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for session in open_sessions %}
-        <tr>
-            <td>{{session.start_date}}</td>
-            <td>{{session.last_modified}}</td>
-            <td>{{session.text}}</td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-{% endif %}
-
-
-
-<h2>Closed sessions</h2>
-{% if closed_sessions %}
-<table class="table">
-    <thead>
-        <tr>
-            <th scope="col">Start date</th>
-            <th scope="col">Last modified</th>
-            <th scope="col">Text</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for session in closed_sessions %}
-        <tr>
-            <td>{{session.start_date}}</td>
-            <td>{{session.last_modified}}</td>
-            <td>{{session.text}}</td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-{% endif %}
-
-
 
 <h2>Canceled sessions</h2>
 <div class='row'>
     <div class='col-md-12'>
-        <h4><span class='badge badge-pill badge-primary'>{{ canceled_sessions | length }}</span> users canceled their session</h4>
-        <p>These users instructed the tool to close thier session, for example, by typing "end." This data shows the question on which users closed their sessions.</p>
+        <h4><span class='badge badge-pill badge-primary'>{{ canceled_sessions }}</span> users canceled their session</h4>
+        <p>These users canceled their session, either by instructing the tool to close thier session (e.g. by typing "end") or by abandoning their session after 24 hours. This chart shows the question or resource on which users canceled their sessions.</p>
         <div id="canceled-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
     </div>
 </div>
 
+<h2>Completed sessions</h2>
 <div class='row'>
     <div class='col-md-12'>
-        {% if canceled_sessions %}
-        <table class="table">
-            <thead>
-                <tr>
-                    <th scope="col">Start date</th>
-                    <th scope="col">Last modified</th>
-                    <th scope="col">Text</th>
-                </tr>
-            </thead>
-            <tbody>
-            {% for session in canceled_sessions %}
-                <tr>
-                    <td>{{session.start_date}}</td>
-                    <td>{{session.last_modified}}</td>
-                    <td>{{session.text}}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-        {% endif %}
+        <h4><span class='badge badge-pill badge-primary'>{{ completed_sessions }}</span> users completed their session</h4>
+        <p>These users completed the entire survey! This chart shows the last resource recommended to the user.</p>
+        <div id="completed-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
     </div>
 </div>
+
+<hr>
+
+<h2>Recommended Resources</h2>
+<div class='row'>
+    <div class='col-md-12'>
+        <p>This chart shows the total number of times each resource has been recommended.</p>
+        <div id="resources-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+    </div>
+</div>
+
+
+
 
 {% endblock %}
 
@@ -98,11 +49,17 @@
 
 <script>
     $(function() {
-        open_chart = '{{open_chart | escapejs}}'
-        barHelper('open-chart' ,open_chart);
+        open_sessions_chart = '{{open_sessions_chart | escapejs}}'
+        barHelper('open-chart', open_sessions_chart);
 
-        canceled_chart = '{{canceled_chart | escapejs}}';
-        barHelper('canceled-chart', canceled_chart);
+        canceled_sessions_chart = '{{canceled_sessions_chart | escapejs}}';
+        barHelper('canceled-chart', canceled_sessions_chart);
+
+        completed_sessions_chart = '{{completed_sessions_chart | escapejs}}';
+        barHelper('completed-chart', completed_sessions_chart);
+
+        resources_chart = '{{resources_chart | escapejs}}';
+        barHelper('resources-chart', resources_chart);
 
     });
 </script>

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -2,6 +2,8 @@
 {% block title %}Dashboard{% endblock %}
 {% block content %}
 
+
+<h2>Open sessions</h2>
 {% if open_sessions %}
 <table class="table">
     <thead>
@@ -23,6 +25,7 @@
 </table>
 {% endif %}
 
+<h2>Closed sessions</h2>
 {% if closed_sessions %}
 <table class="table">
     <thead>
@@ -44,25 +47,49 @@
 </table>
 {% endif %}
 
-{% if canceled_sessions %}
-<table class="table">
-    <thead>
-        <tr>
-            <th scope="col">Start date</th>
-            <th scope="col">Last modified</th>
-            <th scope="col">Text</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for session in canceled_sessions %}
-        <tr>
-            <td>{{session.start_date}}</td>
-            <td>{{session.last_modified}}</td>
-            <td>{{session.text}}</td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-{% endif %}
+<h2>Canceled sessions</h2>
+<div class='row'>
+    <div class='col-md-12'>
+        <h4><span class='badge badge-pill badge-primary'>{{ canceled_sessions | length }}</span> users canceled their session</h4>
+        <p>These users instructed the tool to close thier session, for example, by typing "end." This data shows the question on which users closed their sessions.</p>
+        <div id="container" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+    </div>
+</div>
+
+<div class='row'>
+    <div class='col-md-12'>
+        {% if canceled_sessions %}
+        <table class="table">
+            <thead>
+                <tr>
+                    <th scope="col">Start date</th>
+                    <th scope="col">Last modified</th>
+                    <th scope="col">Text</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for session in canceled_sessions %}
+                <tr>
+                    <td>{{session.start_date}}</td>
+                    <td>{{session.last_modified}}</td>
+                    <td>{{session.text}}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+    </div>
+</div>
 
 {% endblock %}
+
+{% block extra_javascript %}
+
+<script>
+    $(function() {
+        prepped_data = '{{canceled_chart | escapejs}}';
+        barHelper(prepped_data);
+    });
+</script>
+
+{% endblock extra_javascript %}

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+
+{% if open_sessions %}
+<table class="table">
+    <thead>
+        <tr>
+            <th scope="col">Start date</th>
+            <th scope="col">Last modified</th>
+            <th scope="col">Text</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for session in open_sessions %}
+        <tr>
+            <td>{{session.start_date}}</td>
+            <td>{{session.last_modified}}</td>
+            <td>{{session.text}}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+
+{% endblock %}

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -2,7 +2,6 @@
 {% block title %}Dashboard{% endblock %}
 {% block content %}
 
-
 <div class='row'>
     <div class='col-md-10 offset-md-1'>
         <div class='row mt-4'>
@@ -10,7 +9,9 @@
                 <h2>Open sessions</h2>
                 <h4><span class='badge badge-pill badge-primary'>{{ open_sessions }}</span> users have open sessions</h4>
                 <p>These users started a survey in the last 24 hours.</p>
-                <div id="open-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+                {% if open_sessions %}
+                    <div id="open-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+                {% endif %}
             </div>
         </div>
         <div class='row mt-4'>
@@ -25,7 +26,7 @@
             <div class='col-md-12'>
                 <h2>Completed sessions</h2>
                 <h4><span class='badge badge-pill badge-primary'>{{ completed_sessions }}</span> users completed their session</h4>
-                <p>These users completed the entire survey! This chart shows the last resource recommended to the user.</p>
+                <p>These users completed the entire survey! This chart shows the last message or resource sent to the user.</p>
                 <div id="completed-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
             </div>
         </div>
@@ -47,7 +48,9 @@
     $(function() {
         open_sessions_chart = JSON.parse('{{open_sessions_chart | escapejs}}');
         open_sessions_map = JSON.parse('{{open_sessions_map | escapejs}}');
-        barHelper('open-chart', open_sessions_chart, open_sessions_map);
+        if (open_sessions_chart.length != 0) {
+            barHelper('open-chart', open_sessions_chart, open_sessions_map);
+        }
 
         canceled_sessions_chart = JSON.parse('{{canceled_sessions_chart | escapejs}}');
         canceled_sessions_map = JSON.parse('{{canceled_sessions_map | escapejs}}');

--- a/templates/ces_admin/ces-dashboard.html
+++ b/templates/ces_admin/ces-dashboard.html
@@ -3,45 +3,41 @@
 {% block content %}
 
 
-<h2>Open sessions</h2>
 <div class='row'>
-    <div class='col-md-12'>
-        <h4><span class='badge badge-pill badge-primary'>{{ open_sessions }}</span> users have open sessions</h4>
-        <p>These users started a survey in the last 24 hours.</p>
-        <div id="open-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+    <div class='col-md-10 offset-md-1'>
+        <div class='row mt-4'>
+            <div class='col-md-12'>
+                <h2>Open sessions</h2>
+                <h4><span class='badge badge-pill badge-primary'>{{ open_sessions }}</span> users have open sessions</h4>
+                <p>These users started a survey in the last 24 hours.</p>
+                <div id="open-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+            </div>
+        </div>
+        <div class='row mt-4'>
+            <div class='col-md-12'>
+                <h2>Canceled sessions</h2>
+                <h4><span class='badge badge-pill badge-primary'>{{ canceled_sessions }}</span> users canceled their session</h4>
+                <p>These users canceled their session, either by instructing the tool to close thier session (e.g. by typing "end") or by abandoning their session after 24 hours. This chart shows the question or resource on which users canceled their sessions.</p>
+                <div id="canceled-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+            </div>
+        </div>
+        <div class='row mt-4'>
+            <div class='col-md-12'>
+                <h2>Completed sessions</h2>
+                <h4><span class='badge badge-pill badge-primary'>{{ completed_sessions }}</span> users completed their session</h4>
+                <p>These users completed the entire survey! This chart shows the last resource recommended to the user.</p>
+                <div id="completed-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+            </div>
+        </div>
+        <div class='row mt-4'>
+            <div class='col-md-12'>
+                <h2>Recommended Resources</h2>
+                <p>This chart shows the total number of times each resource has been recommended.</p>
+                <div id="resources-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
+            </div>
+        </div>
     </div>
 </div>
-
-<h2>Canceled sessions</h2>
-<div class='row'>
-    <div class='col-md-12'>
-        <h4><span class='badge badge-pill badge-primary'>{{ canceled_sessions }}</span> users canceled their session</h4>
-        <p>These users canceled their session, either by instructing the tool to close thier session (e.g. by typing "end") or by abandoning their session after 24 hours. This chart shows the question or resource on which users canceled their sessions.</p>
-        <div id="canceled-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
-    </div>
-</div>
-
-<h2>Completed sessions</h2>
-<div class='row'>
-    <div class='col-md-12'>
-        <h4><span class='badge badge-pill badge-primary'>{{ completed_sessions }}</span> users completed their session</h4>
-        <p>These users completed the entire survey! This chart shows the last resource recommended to the user.</p>
-        <div id="completed-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
-    </div>
-</div>
-
-<hr>
-
-<h2>Recommended Resources</h2>
-<div class='row'>
-    <div class='col-md-12'>
-        <p>This chart shows the total number of times each resource has been recommended.</p>
-        <div id="resources-chart" style="min-width: 310px; height: 400px; margin: 0 auto"></div>
-    </div>
-</div>
-
-
-
 
 {% endblock %}
 
@@ -49,17 +45,21 @@
 
 <script>
     $(function() {
-        open_sessions_chart = '{{open_sessions_chart | escapejs}}'
-        barHelper('open-chart', open_sessions_chart);
+        open_sessions_chart = JSON.parse('{{open_sessions_chart | escapejs}}');
+        open_sessions_map = JSON.parse('{{open_sessions_map | escapejs}}');
+        barHelper('open-chart', open_sessions_chart, open_sessions_map);
 
-        canceled_sessions_chart = '{{canceled_sessions_chart | escapejs}}';
-        barHelper('canceled-chart', canceled_sessions_chart);
+        canceled_sessions_chart = JSON.parse('{{canceled_sessions_chart | escapejs}}');
+        canceled_sessions_map = JSON.parse('{{canceled_sessions_map | escapejs}}');
+        barHelper('canceled-chart', canceled_sessions_chart, canceled_sessions_map);
 
-        completed_sessions_chart = '{{completed_sessions_chart | escapejs}}';
-        barHelper('completed-chart', completed_sessions_chart);
+        completed_sessions_chart = JSON.parse('{{completed_sessions_chart | escapejs}}');
+        completed_sessions_map = JSON.parse('{{completed_sessions_map | escapejs}}');
+        barHelper('completed-chart', completed_sessions_chart, completed_sessions_map);
 
-        resources_chart = '{{resources_chart | escapejs}}';
-        barHelper('resources-chart', resources_chart);
+        resources_chart = JSON.parse('{{resources_chart | escapejs}}');
+        resources_map = JSON.parse('{{resources_map | escapejs}}');
+        barHelper('resources-chart', resources_chart, resources_map);
 
     });
 </script>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+from pytest_django.fixtures import db
+from django.contrib.auth.models import User
+
+@pytest.fixture
+@pytest.mark.django_db
+def auth_client(db, client):
+    User.objects.create_user(username='admin', password='password')
+    client.login(username='admin', password='password')
+    
+    return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,18 @@ def db_setup(db, session):
     '''
     Populate the database with one open, canceled, and completed session.
     '''
+    open_session = {
+        'last_modified': (datetime.now() - timedelta(hours=5)),
+    }
+
+    session.build(**open_session)
+
+    canceled_session = {
+        'canceled': True,
+        'state_id': None,
+    }
+
+    session.build(**canceled_session)
 
 
 @pytest.fixture
@@ -89,8 +101,7 @@ def session(db, tree_state, connection, tree):
         def build(self, **kwargs):
             session_info = {
                 'id': randrange(1000000),
-                # for an open session
-                'last_modified': (datetime.now() - timedelta(hours=5)), 
+                'last_modified': '2018-10-26 13:14:29.629877-05', 
                 'state_id': tree_state.id,
                 'tree_id': tree.id,
                 'num_tries': 0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,20 @@
 import pytest
+from random import randrange
+from datetime import datetime, timedelta
 
 from pytest_django.fixtures import db
+
 from django.contrib.auth.models import User
+from rapidsms.models import Connection, Backend
+from decisiontree.models import Session, TreeState, Message, Tree
+
+@pytest.fixture
+@pytest.mark.django_db
+def db_setup(db, session):
+    '''
+    Populate the database with one open, canceled, and completed session.
+    '''
+
 
 @pytest.fixture
 @pytest.mark.django_db
@@ -10,3 +23,85 @@ def auth_client(db, client):
     client.login(username='admin', password='password')
     
     return client
+
+@pytest.fixture
+@pytest.mark.django_db
+def message(db):
+    message_info = {
+        'id': 1, 
+        'text': 'How old are you?',
+    }
+
+    message = Message.objects.create(**message_info)
+    message.save()
+
+    return message
+
+@pytest.fixture
+@pytest.mark.django_db
+def tree_state(db, message):
+    state_info = {
+        'id': 1, 
+        'name': 'age question',
+        'message_id': message.id,
+    }
+
+    state = TreeState.objects.create(**state_info)
+    state.save()
+
+    return state
+
+@pytest.fixture
+@pytest.mark.django_db
+def tree(db, tree_state):
+    tree_info = {
+        'id': 1, 
+        'summary': 'CES survey',
+        'trigger': 'start',
+        'root_state_id': tree_state.id,
+    }
+
+    tree = Tree.objects.create(**tree_info)
+    tree.save()
+
+    return tree
+
+@pytest.fixture
+@pytest.mark.django_db
+def connection(db, message):
+    backend = Backend.objects.create(name='twilio-backend')
+
+    connection_info = {
+        'id': 1, 
+        'created_on': '2018-08-15 16:10:32.180409-05',
+        'backend_id': backend.id,
+    }
+
+    connection = Connection.objects.create(**connection_info)
+    connection.save()
+
+    return connection
+
+@pytest.fixture
+@pytest.mark.django_db
+def session(db, tree_state, connection, tree):
+    class SessionFactory():
+        def build(self, **kwargs):
+            session_info = {
+                'id': randrange(1000000),
+                # for an open session
+                'last_modified': (datetime.now() - timedelta(hours=5)), 
+                'state_id': tree_state.id,
+                'tree_id': tree.id,
+                'num_tries': 0,
+                'connection_id': connection.id,
+            }
+
+            session_info.update(**kwargs)
+
+            session = Session.objects.create(**session_info)
+            session.save()
+
+            return session 
+
+    return SessionFactory()

--- a/tests/test_admin_tools.py
+++ b/tests/test_admin_tools.py
@@ -4,12 +4,29 @@ from django.urls import reverse
 
 from ces_admin.utils import prepare_data
 
-def test_dashboard(auth_client):
+def _test_dashboard_helper(auth_client):
     url = reverse('dashboard')
-    
-    rv = auth_client.post(url)
+    response = auth_client.get(url)
 
-    assert rv.status == 200
+    assert response.status_code == 200
 
-def test_prepare_data():
-    assert True == True
+    return response
+
+def test_open_sessions(auth_client):
+    response = _test_dashboard_helper(auth_client)
+
+    assert response.context['open_sessions'] == 0
+
+def test_canceled_sessions(auth_client):
+    response = _test_dashboard_helper(auth_client)
+
+    assert response.context['canceled_sessions'] == 0
+
+def test_completed_sessions(auth_client):
+    response = _test_dashboard_helper(auth_client)
+
+    assert response.context['completed_sessions'] == 0
+
+# TODO: create session fixtures for testing! 
+# Test the count for each type of session, chart data, and mapping data.
+# Add pytest to travis

--- a/tests/test_admin_tools.py
+++ b/tests/test_admin_tools.py
@@ -4,29 +4,34 @@ from django.urls import reverse
 
 from ces_admin.utils import prepare_data
 
-def _test_dashboard_helper(auth_client):
-    url = reverse('dashboard')
-    response = auth_client.get(url)
+def test_open_sessions(auth_client, session):
+    response = _get_dashboard_helper(auth_client)
 
-    assert response.status_code == 200
+    session = session.build()
 
-    return response
+    import pdb
+    pdb.set_trace()
 
-def test_open_sessions(auth_client):
-    response = _test_dashboard_helper(auth_client)
-
-    assert response.context['open_sessions'] == 0
+    assert response.context['open_sessions'] == 1
 
 def test_canceled_sessions(auth_client):
-    response = _test_dashboard_helper(auth_client)
+    response = _get_dashboard_helper(auth_client)
 
     assert response.context['canceled_sessions'] == 0
 
 def test_completed_sessions(auth_client):
-    response = _test_dashboard_helper(auth_client)
+    response = _get_dashboard_helper(auth_client)
 
     assert response.context['completed_sessions'] == 0
 
 # TODO: create session fixtures for testing! 
 # Test the count for each type of session, chart data, and mapping data.
 # Add pytest to travis
+
+def _get_dashboard_helper(auth_client):
+    url = reverse('dashboard')
+    response = auth_client.get(url)
+
+    assert response.status_code == 200
+
+    return response

--- a/tests/test_admin_tools.py
+++ b/tests/test_admin_tools.py
@@ -4,29 +4,18 @@ from django.urls import reverse
 
 from ces_admin.utils import prepare_data
 
-def test_open_sessions(auth_client, session):
+def test_open_sessions(auth_client, db_setup):
     response = _get_dashboard_helper(auth_client)
-
-    session = session.build()
-
-    import pdb
-    pdb.set_trace()
-
     assert response.context['open_sessions'] == 1
 
-def test_canceled_sessions(auth_client):
+def test_canceled_sessions(auth_client, db_setup):
     response = _get_dashboard_helper(auth_client)
-
-    assert response.context['canceled_sessions'] == 0
+    assert response.context['canceled_sessions'] == 1
 
 def test_completed_sessions(auth_client):
     response = _get_dashboard_helper(auth_client)
 
     assert response.context['completed_sessions'] == 0
-
-# TODO: create session fixtures for testing! 
-# Test the count for each type of session, chart data, and mapping data.
-# Add pytest to travis
 
 def _get_dashboard_helper(auth_client):
     url = reverse('dashboard')

--- a/tests/test_admin_tools.py
+++ b/tests/test_admin_tools.py
@@ -1,0 +1,15 @@
+import pytest
+
+from django.urls import reverse
+
+from ces_admin.utils import prepare_data
+
+def test_dashboard(auth_client):
+    url = reverse('dashboard')
+    
+    rv = auth_client.post(url)
+
+    assert rv.status == 200
+
+def test_prepare_data():
+    assert True == True

--- a/tests/test_admin_tools.py
+++ b/tests/test_admin_tools.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 
 from django.urls import reverse
 
@@ -8,14 +9,20 @@ def test_open_sessions(auth_client, db_setup):
     response = _get_dashboard_helper(auth_client)
     assert response.context['open_sessions'] == 1
 
+def test_open_sessions_chart(auth_client, db_setup):
+    response = _get_dashboard_helper(auth_client)
+    chart_data = json.loads(response.context['open_sessions_chart'])[0]
+
+    assert chart_data.get('y') == 1
+    assert chart_data.get('name') == 'How old are you?'
+
 def test_canceled_sessions(auth_client, db_setup):
     response = _get_dashboard_helper(auth_client)
     assert response.context['canceled_sessions'] == 1
 
-def test_completed_sessions(auth_client):
+def test_completed_sessions(auth_client, db_setup):
     response = _get_dashboard_helper(auth_client)
-
-    assert response.context['completed_sessions'] == 0
+    assert response.context['completed_sessions'] == 1
 
 def _get_dashboard_helper(auth_client):
     url = reverse('dashboard')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import os
+
 SECRET_KEY = 'test test test'
 
 INSTALLED_APPS = [
@@ -50,3 +52,37 @@ DATABASES = {
 } 
 
 ROOT_URLCONF = 'coordinated-entry-screening.urls'
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_URL = '/static/'
+
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "coordinated-entry-screening", "static"),
+]
+
+STATICFILES_FINDERS = [
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
+            ],
+        },
+    },
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+SECRET_KEY = 'test test test'
+
+INSTALLED_APPS = [
+    'ces_client',
+    'ces_admin',
+    'rapidsms',
+    # third party apps.
+    'django_tables2',
+    'selectable',
+    'decisiontree',
+    'rtwilio',
+    # django contrib apps
+    'django.contrib.auth',
+    'django.contrib.admin',
+    'django.contrib.messages',
+    'django.contrib.sessions',
+    'django.contrib.staticfiles',
+    'django.contrib.contenttypes',
+    # rapidsms contrib apps.
+    'rapidsms.contrib.handlers',
+    'rapidsms.contrib.httptester',
+    'rapidsms.contrib.messagelog',
+    'rapidsms.contrib.messaging',
+    'rapidsms.contrib.registration',
+    'rapidsms.contrib.echo',
+    'rapidsms.router.db',
+    'rapidsms.backends.database',
+    'rapidsms.backends.kannel',
+    'rapidsms.tests.translation',
+
+    'rapidsms.contrib.default',  # Should be last
+]
+
+MIDDLEWARE = [
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'coordinated-entry-screening',
+        'USER': '',
+        'PASSWORD': '',
+        'PORT': 5432,
+    }
+} 
+
+ROOT_URLCONF = 'coordinated-entry-screening.urls'


### PR DESCRIPTION
This PR organizes data for the admin dashboard. A summary of what we plan to show (from the SOW):

* show how many people started a process
* for those who complete the process, what resource they were connected to
* for those who don’t complete the process, the tool will show the step they fell off on.

I accomplished this by selecting data for ["open sessions"](https://github.com/datamade/coordinated-entry-screening/pull/49/files#diff-a4783bc685c6953b54b76538a03b3973R57), ["canceled sessions,"](https://github.com/datamade/coordinated-entry-screening/pull/49/files#diff-a4783bc685c6953b54b76538a03b3973R68) and ["completed sessions"](https://github.com/datamade/coordinated-entry-screening/pull/49/files#diff-a4783bc685c6953b54b76538a03b3973R81). These get rendered in the template as simple bar charts. 

I also have a chart for the all resources recommended (regardless of session type). https://github.com/datamade/coordinated-entry-screening/pull/49/files#diff-a4783bc685c6953b54b76538a03b3973R92